### PR TITLE
Convert package name from string to enum literal

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "mpack-zig",
+    .name = .mpack_zig,
     .version = "0.0.0",
     .minimum_zig_version = "0.13.0",
 


### PR DESCRIPTION
From https://github.com/ziglang/zig/issues/20178

> Package names gain new rules:
>
> - Limited to 32 bytes
> - Must be a legal unquoted identifier in Zig source code (/[A-Za-z_][A-Za-z0-9_]*/)
>   - Package names therefore will be represented as an enum literal in .zon format. Using a string will be deprecated.